### PR TITLE
config: Reduce homing speed for Ender 3

### DIFF
--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -19,7 +19,7 @@ step_distance: .0125
 endstop_pin: ^PC2
 position_endstop: 0
 position_max: 235
-homing_speed: 50
+homing_speed: 25
 
 [stepper_y]
 step_pin: PC6
@@ -29,7 +29,7 @@ step_distance: .0125
 endstop_pin: ^PC3
 position_endstop: 0
 position_max: 235
-homing_speed: 50
+homing_speed: 25
 
 [stepper_z]
 step_pin: PB3


### PR DESCRIPTION
The default homing speed of 50 for the Ender 3 causes the head to slam into the endstops with disconcerting force.